### PR TITLE
add debug support in xmake

### DIFF
--- a/scripts/xmake/verilator.lua
+++ b/scripts/xmake/verilator.lua
@@ -175,7 +175,14 @@ function emu_comp(num_cores)
     verilator_flags = verilator_flags .. " --threads " .. option.get("threads") .. " --threads-dpi all"
   end
   if not option.get("fast") then
-    verilator_flags = verilator_flags .. " --trace"
+    if option.get("debug") then
+      if option.get("wave") then
+        verilator_flags = verilator_flags .. " --trace-fst"
+        cxx_flags = cxx_flags .. " -DENABLE_FST"
+      end
+    else
+      verilator_flags = verilator_flags .. " --trace"
+    end
   end
   if not option.get("no_diff") then
     verilator_flags = verilator_flags .. " +define+DIFFTEST"
@@ -295,7 +302,13 @@ function emu_run()
   os.cd(emu_case_dir)
 
   local sh_str = "chmod +x emu" .. " && ( ./emu"
-  if option.get("dump") then
+  if option.get("debug") then
+    sh_str = sh_str .. " --no-diff  "
+    sh_str = sh_str .. " --enable-jtag " .. " --remote-jtag-port " .. option.get("debug")
+    if option.get("wave") then
+      sh_str = sh_str .. " --dump-wave-full "
+    end
+  elseif option.get("dump") then
     sh_str = sh_str .. " --dump-wave"
     if(wave_begin ~= "0") then sh_str = sh_str .. " -b " .. wave_begin end
     if(wave_end ~= "0") then sh_str = sh_str .. " -e " .. wave_end end
@@ -308,11 +321,16 @@ function emu_run()
   if(cycles ~= "0") then sh_str = sh_str .. " -C " .. cycles end
   if(gcpt_restore ~= "") then sh_str = sh_str .. " -r " .. gcpt_restore end
   if(flash_file ~= "") then sh_str = sh_str .. " -F " .. flash_file end
-
-  sh_str = sh_str .. " --diff " .. ref_so
+  if not option.get("debug") then
+    sh_str = sh_str .. " --diff " .. ref_so
+  end
   sh_str = sh_str .. " -i " .. image_file
   sh_str = sh_str .. " -s " .. option.get("seed")
-  sh_str = sh_str .. " --wave-path " .. case_name .. ".vcd"
+  if(option.get("debug")) then
+    sh_str = sh_str .. " --wave-path " .. case_name .. ".fst"
+  else
+    sh_str = sh_str .. " --wave-path " .. case_name .. ".vcd"
+  end
   sh_str = sh_str .. " ) 2>assert.log |tee run.log"
 
   io.writefile("tmp.sh", sh_str)

--- a/xmake.lua
+++ b/xmake.lua
@@ -135,6 +135,8 @@ task("emu", function()
       {'S', "socket", "kv", "sync", "define how cpu cluster connect to noc"},
       {'o', "build_dir", "kv", nil, "assign build dir"},
       {nil, "sim_dir", "kv", nil, "assign simulation dir"},
+      {nil, "debug", "k", nil, "only debug need"},
+      {nil, "wave", "k", nil, "set --dump-wave-full xxx.fst"},
     }
   }
 
@@ -171,6 +173,8 @@ task("emu-run", function ()
       {nil, "case_name", "kv", nil, "user defined case name"},
       {'o', "build_dir", "kv", nil, "assign build dir"},
       {nil, "sim_dir", "kv", nil, "assign simulation dir"},
+      {nil, "debug", "kv", nil, "set --remote-jtag-port={value} && --enable-jtag && --no-diff"},
+      {nil, "wave", "k", nil, "set --dump-wave-full"},
     }
   }
 


### PR DESCRIPTION
It does not affect the use of non-debug features and adds support for the compilation and execution of debug-related functionality with verilator.